### PR TITLE
upgraded dependency library versions to work with flask 1.0.x

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,8 @@
 flake8==2.4.1
-tox==2.1.1
-tox-pyenv==1.0.3
+tox==3.1.0
+tox-pyenv==1.1.0
 coverage==4.0
 flask_sqlalchemy
-pytest
+pytest==4.0.0
+pluggy>=0.7
 -e .

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ except:
     long_description = 'Route inheritance for Flask Blueprints'
 
 requirements = [
-    "flask>=0.11.1, <1.0",
+    "flask>=0.11.1",
     "six>=1.10.0, <2.0"
 ]
 


### PR DESCRIPTION
Hi, 
We couldn't use this library with flask 1.0.x. Have upgraded all the dependent libraries to recent versions. 